### PR TITLE
Feature/support multi module

### DIFF
--- a/src/main/scala/sbtrelease/gitflow/Config.scala
+++ b/src/main/scala/sbtrelease/gitflow/Config.scala
@@ -3,7 +3,7 @@ package sbtrelease.gitflow
 import java.io.File
 
 import sbt.{Extracted, Logger}
-import sbt.Keys.version
+import sbt.Keys.{name, version}
 import sbtrelease.Version
 import ReleasePlugin.autoImport._
 
@@ -19,7 +19,8 @@ case class Config(
   calcNextSnapshotVersion: Version => Version,
   calcVersionChangeCommitMessage: Version => String,
   calcTag: Version => (String,String),
-  versionFile: File
+  versionFile: File,
+  artifactName: String
 )
 
 object Config {
@@ -33,6 +34,7 @@ object Config {
     val calcVersionChangeCommitMessage = e.get(releaseCalcVersionChangeCommitMessage)
     val calcTag = e.get(releaseCalcTag)
     val versionFile = e.get(releaseVersionFile)
+    val artifactName = e.get(name)
 
     Config(
       log = log,
@@ -46,7 +48,8 @@ object Config {
       calcNextSnapshotVersion = calcNextSnapshotVersion,
       calcVersionChangeCommitMessage = calcVersionChangeCommitMessage,
       calcTag = calcTag,
-      versionFile = versionFile
+      versionFile = versionFile,
+      artifactName = artifactName
     )
   }
 }

--- a/src/main/scala/sbtrelease/gitflow/Git.scala
+++ b/src/main/scala/sbtrelease/gitflow/Git.scala
@@ -181,7 +181,7 @@ object Git {
 
   def isRepository(dir: File): Option[File] =
     if (new File(dir, markerDirectory).isDirectory) Some(dir)
-    else Option(dir.getParentFile).flatMap(isRepository)
+    else Option(dir.getAbsoluteFile.getParentFile).flatMap(isRepository)
 
   protected val markerDirectory = ".git"
 }

--- a/src/main/scala/sbtrelease/gitflow/ReleasePlugin.scala
+++ b/src/main/scala/sbtrelease/gitflow/ReleasePlugin.scala
@@ -71,7 +71,7 @@ object ReleasePlugin extends AutoPlugin {
           val helper = new Helper(cfg)
           import helper._
 
-          findReleaseBranch(searchRemote = true) match {
+          findReleaseBranch(searchRemote = true, artifactName) match {
             case Some(releaseBranch) =>
               // Checkout in case its only on remote
               checkoutBranch(releaseBranch)
@@ -128,7 +128,7 @@ object ReleasePlugin extends AutoPlugin {
       ensureNotBehindRemote()
 
       log.info("Ensuring no release branch is already present... ")
-      findReleaseBranch(searchRemote = true) match {
+      findReleaseBranch(searchRemote = true,artifactName) match {
         case Some(releaseBranch) =>
           if(flags.skipIfExists) {
             log.info("Skipping creating release branch")
@@ -186,7 +186,7 @@ object ReleasePlugin extends AutoPlugin {
       import helper._
 
       ensureStagingClean()
-      val releaseBranch = findReleaseBranch(searchRemote = false).getOrDie("Could not find release branch!")
+      val releaseBranch = findReleaseBranch(searchRemote = false,artifactName).getOrDie("Could not find release branch!")
       ensureCurrentBranch(releaseBranch)
       // If skipPush is set then there may not be a tracking remote for the release branch
       // since create was probably called with skipPush

--- a/src/main/scala/sbtrelease/gitflow/ReleaseStateTransformations.scala
+++ b/src/main/scala/sbtrelease/gitflow/ReleaseStateTransformations.scala
@@ -326,13 +326,13 @@ object ReleaseStateTransformations {
       val defaultChoice = if(useDefs) Some("y") else None
       defaultChoice orElse SimpleReader.readLine(s"Delete branch $branch (y/n)? [y] ") match {
         case Some("y") | Some("") =>
-          git.deleteLocalBranch(branch)
           if(!skipPush) {
             val remote = git.trackingRemote(branch)
             git.deleteRemoteBranch(remote, branch)
           } else {
             info(s"Skipping deleting remote branch $branch...")
           }
+          git.deleteLocalBranch(branch)
         case _ =>
       }
     }

--- a/src/main/scala/sbtrelease/gitflow/ReleaseStateTransformations.scala
+++ b/src/main/scala/sbtrelease/gitflow/ReleaseStateTransformations.scala
@@ -55,11 +55,11 @@ object ReleaseStateTransformations {
       info("Starting release process off commit: " + git.currentHash)
     }
     
-    def findReleaseBranch(searchRemote: Boolean) : Option[String] = {
+    def findReleaseBranch(searchRemote: Boolean, artifactName: String) : Option[String] = {
       val result =
-        git.localBranches.find(_.startsWith("release/")) orElse {
+        git.localBranches.find(_.startsWith(s"release/${artifactName}")) orElse {
           if(searchRemote) {
-            git.remoteBranches.find(_._2.startsWith("release/")).map(_._2)
+            git.remoteBranches.find(_._2.startsWith(s"release/${artifactName}")).map(_._2)
           } else {
             None
           }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0-SNAPSHOT"
+version in ThisBuild := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
Hi Lance,
Thank you for authoring and sharing this plugin.  

Your antipathy towards gitflow may render this PR useless, in that you may choose to ignore it completely, however in the off-chance this catches your eye, please find a short summary below of my small changes.

1. Two bugfixes which I noticed when running git client v2.15.1 on macOS High Sierra. Namely: a) Use the absolute path to correctly locate parent git directory and b) Remove remote branch before local branch
2. One feature enhancement to support multi-module builds in the same repository by using the module name as a prefix for both release branches and tags.

I've bumped the version to 1.1.0 to reflect these changes.

Regards,
Darragh